### PR TITLE
Guard unsafe imports behind !appengine

### DIFF
--- a/terminal_check_bsd.go
+++ b/terminal_check_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin dragonfly freebsd netbsd openbsd
+// +build !appengine
 
 package logrus
 
@@ -10,4 +11,3 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
-

--- a/terminal_check_solaris.go
+++ b/terminal_check_solaris.go
@@ -1,3 +1,6 @@
+// +build solaris
+// +build !appengine
+
 package logrus
 
 import (

--- a/terminal_check_unix.go
+++ b/terminal_check_unix.go
@@ -1,4 +1,5 @@
 // +build linux aix
+// +build !appengine
 
 package logrus
 
@@ -10,4 +11,3 @@ func isTerminal(fd int) bool {
 	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
 	return err == nil
 }
-

--- a/terminal_check_windows.go
+++ b/terminal_check_windows.go
@@ -1,4 +1,4 @@
-// +build !appengine,!js,windows
+// +build windows
 
 package logrus
 


### PR DESCRIPTION
"unsafe" (in this case, imported via "golang.org/x/sys/unix") cannot be
used on AppEngine, so we need to add the "!appengine" build constraint
to files that use it (namely a few terminal_check_*.go).